### PR TITLE
Add Tides Service 

### DIFF
--- a/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/TidesQueryService.java
+++ b/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/TidesQueryService.java
@@ -25,7 +25,7 @@ public class TidesQueryService {
     }
 
     // Documentation for endpoint is at: https://api.tidesandcurrents.noaa.gov/api/prod/
-    public static final String ENDPOINT = "";
+    public static final String ENDPOINT = "https://api.tidesandcurrents.noaa.gov/api/prod/datagetter?application=ucsb-cs156&begin_date={beginDate}&end_date={endDate}&station={station}&product=predictions&datum=mllw&units=english&time_zone=lst_ldt&interval=hilo&format=json";
 
     public String getJSON(String beginDate, String endDate, String station) throws HttpClientErrorException {
         return "";

--- a/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/TidesQueryService.java
+++ b/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/TidesQueryService.java
@@ -1,11 +1,10 @@
 package edu.ucsb.cs156.spring.backenddemo.services;
 
 
-
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.springframework.web.client.RestTemplate;
-
+import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 
 import org.springframework.boot.web.client.RestTemplateBuilder;
@@ -13,7 +12,7 @@ import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.HttpClientErrorException;
 
-
+@Slf4j
 @Service
 public class TidesQueryService {
 
@@ -28,6 +27,9 @@ public class TidesQueryService {
     public static final String ENDPOINT = "https://api.tidesandcurrents.noaa.gov/api/prod/datagetter?application=ucsb-cs156&begin_date={beginDate}&end_date={endDate}&station={station}&product=predictions&datum=mllw&units=english&time_zone=lst_ldt&interval=hilo&format=json";
 
     public String getJSON(String beginDate, String endDate, String station) throws HttpClientErrorException {
-        return "";
+        log.info("beginDate={}, endDate={}, station={}", beginDate, endDate, station);
+        Map<String, String> uriVariables = Map.of("beginDate", beginDate, "endDate", endDate, "station", station);
+
+        return restTemplate.getForObject(ENDPOINT, String.class, uriVariables);
     }
 }

--- a/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/TidesQueryService.java
+++ b/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/TidesQueryService.java
@@ -1,14 +1,20 @@
 package edu.ucsb.cs156.spring.backenddemo.services;
 
+import java.util.List;
+import java.util.Map;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.springframework.web.client.RestTemplate;
-import java.util.Map;
+
 import lombok.extern.slf4j.Slf4j;
 
 import org.springframework.boot.web.client.RestTemplateBuilder;
-
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.HttpClientErrorException;
 
@@ -28,8 +34,14 @@ public class TidesQueryService {
 
     public String getJSON(String beginDate, String endDate, String station) throws HttpClientErrorException {
         log.info("beginDate={}, endDate={}, station={}", beginDate, endDate, station);
-        Map<String, String> uriVariables = Map.of("beginDate", beginDate, "endDate", endDate, "station", station);
 
-        return restTemplate.getForObject(ENDPOINT, String.class, uriVariables);
+        HttpHeaders headers = new HttpHeaders();
+        headers.setAccept(List.of(MediaType.APPLICATION_JSON));
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        HttpEntity<String> entity = new HttpEntity<>(headers);
+
+        Map<String,String> uriVariables = Map.of("beginDate", beginDate, "endDate", endDate, "station", station);
+        
+        return restTemplate.exchange(ENDPOINT, HttpMethod.GET, entity, String.class, uriVariables).getBody();
     }
 }

--- a/src/test/java/edu/ucsb/cs156/spring/backenddemo/services/TidesQueryServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/spring/backenddemo/services/TidesQueryServiceTests.java
@@ -1,0 +1,41 @@
+package edu.ucsb.cs156.spring.backenddemo.services;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.header;
+
+@RestClientTest(TidesQueryService.class)
+public class TidesQueryServiceTests {
+
+    @Autowired
+    private MockRestServiceServer mockRestServiceServer;
+
+    @Autowired
+    private TidesQueryService tidesQueryService;
+
+    @Test
+    public void test_getJSON() {
+        String beginDate = "20230101";
+        String endDate = "20231231";
+        String station = "9411340";
+        String expectedURL = TidesQueryService.ENDPOINT.replace("{beginDate}", beginDate)
+                .replace("{endDate}", endDate).replace("{station}", station);
+
+        String fakeJsonResult = "{ \"fake\" : \"result\" }";
+
+        mockRestServiceServer.expect(requestTo(expectedURL))
+                .andExpect(header("Accept", MediaType.APPLICATION_JSON.toString()))
+                .andExpect(header("Content-Type", MediaType.APPLICATION_JSON.toString()))
+                .andRespond(withSuccess(fakeJsonResult, MediaType.APPLICATION_JSON));
+
+        assertEquals(fakeJsonResult, tidesQueryService.getJSON(beginDate, endDate, station));
+    }
+}


### PR DESCRIPTION
In this PR, we add an endpoint `/api/zipcode/get` that can be used to get information about the tides at a station through a specific date range.